### PR TITLE
Add hyperterm-open-devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hypercwd](https://www.npmjs.com/package/hypercwd) - Open new tabs with the same directory as your current tab.
 * [hyperterm-1password](https://www.npmjs.com/package/hyperterm-1password) - Integration with 1Password (password manager).
 * [hyperterm-visor](https://github.com/CWSpear/hyperterm-visor) - Show/hide your HyperTerm terminal with a global hotkey & more.
+* [hyperterm-open-devtools](https://www.npmjs.com/package/hyperterm-open-devtools) - Open DevTools for currently showing web page with a hotkey.
 * Know of another Hyperterm package? [Help add it!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Themes


### PR DESCRIPTION
This [package](https://www.npmjs.com/package/hyperterm-open-devtools) is used for toggle devtools for currently showing web page:

![Screenshot](https://cloud.githubusercontent.com/assets/3001525/16934145/35968d36-4d86-11e6-8f1f-affcc9c07543.gif)

Use a configurable hotkey to open DevTools.