### PR TITLE
Correct the capitalization of HyperTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome HyperTerm [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-[<img src="https://cdn.rawgit.com/bnb/awesome-hyperterm/master/Hyperterm-Mark-Large.png" align="right" width="240">](https://hyperterm.org)
+[<img src="https://cdn.rawgit.com/bnb/awesome-hyperterm/master/HyperTerm-Mark-Large.png" align="right" width="240">](https://hyperterm.org)
 
 > A curated list of sweet HyperTerm [packages](#packages), [themes](#themes), and [resources](#resources).
 
@@ -10,13 +10,13 @@
 
 **Check out the official [HyperTerm site](https://hyperterm.org), checkout [Zeit](https://zeit.co), and their interesting Hosting product, [Now](https://zeit.co/now).**
 
-Want to add your awesome Hyperterm package, theme, or resource? [Create an issue](https://github.com/bnb/awesome-hyperterm/issues/new) or send a PR!
+Want to add your awesome HyperTerm package, theme, or resource? [Create an issue](https://github.com/bnb/awesome-hyperterm/issues/new) or send a PR!
 
 Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twitter.com/bitandbang)! 👋
 
 <!-- AWESOME ITEM TEMPLATE --
 
-* [Hyperterm Awesome Name](hyperterm.awesome.link) - Kick-arse description of why the Package, Theme, or resource is AWESOME!
+* [HyperTerm Awesome Name](hyperterm.awesome.link) - Kick-arse description of why the Package, Theme, or resource is AWESOME!
 
 -- /AWESOME ITEM TEMPLATE -->
 
@@ -27,16 +27,16 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 - [Resources](#resources)
 
 # Packages
-* [hypertheme](https://www.npmjs.com/package/hypertheme) - A theme manager for Hyperterm, published right off the bat. You should import your favorite text-editor or terminal theme and [add it to awesome-hyperterm](https://github.com/bnb/awesome-hyperterm/issues/new)!
-* [hyperpower](https://www.npmjs.com/package/hyperpower) - Add a pinch of kick-arse raw POWER to your Hyperterm! Adds the pixel-explosion and shake effect that's been implemented in several text editors.
-* [hyperline](https://www.npmjs.com/package/hyperline) - A status line at the bottom of your Hyperterm!
+* [hypertheme](https://www.npmjs.com/package/hypertheme) - A theme manager for HyperTerm, published right off the bat. You should import your favorite text-editor or terminal theme and [add it to awesome-hyperterm](https://github.com/bnb/awesome-hyperterm/issues/new)!
+* [hyperpower](https://www.npmjs.com/package/hyperpower) - Add a pinch of kick-arse raw POWER to your HyperTerm! Adds the pixel-explosion and shake effect that's been implemented in several text editors.
+* [hyperline](https://www.npmjs.com/package/hyperline) - A status line at the bottom of your HyperTerm!
 * [hyperterm-blink](https://www.npmjs.com/package/hyperterm-blink) - Make your cursor blink.
-* [hyperborder](https://github.com/webmatze/hyperborder) - Add a gradient border with the same colors as in the Hyperterm logo
-* [hyperterm-transparent-bg](https://www.npmjs.com/package/hyperterm-transparent-bg) - add a transparent background to your Hyperterm through an interesting HTML hack.
+* [hyperborder](https://github.com/webmatze/hyperborder) - Add a gradient border with the same colors as in the HyperTerm logo
+* [hyperterm-transparent-bg](https://www.npmjs.com/package/hyperterm-transparent-bg) - add a transparent background to your HyperTerm through an interesting HTML hack.
 * [hypercwd](https://www.npmjs.com/package/hypercwd) - Open new tabs with the same directory as your current tab.
 * [hyperterm-1password](https://www.npmjs.com/package/hyperterm-1password) - Integration with 1Password (password manager).
 * [hyperterm-visor](https://github.com/CWSpear/hyperterm-visor) - Show/hide your HyperTerm terminal with a global hotkey & more.
-* Know of another Hyperterm package? [Help add it!](https://github.com/bnb/awesome-hyperterm/issues/new)
+* Know of another HyperTerm package? [Help add it!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Themes
 * [hyperterm-atom-dark](https://www.npmjs.com/package/hyperterm-atom-dark) - Dark - Really beautiful import of Atom One Dark theme from the [official Atom theme](https://github.com/atom/one-dark-syntax).
@@ -44,7 +44,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-solarized-dark](https://www.npmjs.com/package/hyperterm-solarized-dark) - Dark - Pleasant and carefully chosen colors based on the popular [solarized](http://ethanschoonover.com/solarized) pallete.
 * [hyperterm-colors](https://www.npmjs.com/package/hyperterm-colors) - Dark - Sweet dark color scheme with a chocolate-y brown background and a pretty set of muted colors!
 * [hyperterm-snazzy](https://www.npmjs.com/package/hyperterm-snazzy) - Dark - Elegant theme with bright colors.
-* [hyperterm-gruvbox-dark](https://www.npmjs.com/package/hyperterm-gruvbox-dark) - Dark - Hyperterm theme with retro, earthy groove colors based on the [gruvbox](https://github.com/morhetz/gruvbox) vim color scheme.
+* [hyperterm-gruvbox-dark](https://www.npmjs.com/package/hyperterm-gruvbox-dark) - Dark - HyperTerm theme with retro, earthy groove colors based on the [gruvbox](https://github.com/morhetz/gruvbox) vim color scheme.
 * [hyperpanic](https://www.npmjs.com/package/hyperpanic) - Dark - A very pretty theme close to the Panic theme's colors. Dark blue background with very bright highlight colors.
 * [hyperterm-tomorrow-night](https://www.npmjs.com/package/hyperterm-tomorrow-night) - Dark - Port of the popular Tomorrow Night theme.
 * [hyperseti](https://www.npmjs.com/package/hyperseti) - Dark - It's a theme based on [Seti](https://github.com/jesseweed/seti-ui), a subtle dark colored UI theme for Atom.
@@ -53,6 +53,6 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * Know of another really awesome theme? [Get it on awesome-hyperterm!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Resources
-* [Official Hyperterm Website](https://hyperterm.org/) - The official Hyperterm website.
+* [Official HyperTerm Website](https://hyperterm.org/) - The official HyperTerm website.
 * [hpm](https://github.com/matheuss/hpm) - A plugin manager for HyperTerm
-* Know of another Hyperterm resource? [Share the love!](https://github.com/bnb/awesome-hyperterm/issues/new)
+* Know of another HyperTerm resource? [Share the love!](https://github.com/bnb/awesome-hyperterm/issues/new)


### PR DESCRIPTION
#33 
This pull request corrects the capitalization of **HyperTerm** 🤓
https://hyperterm.org

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
