### PR TITLE
Add hyperterm-title

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-spacegray](https://www.npmjs.com/package/hyperterm-spacegray) – Port of the popular Spacegray theme, optimized for terminal usage.
 * [hyperhue](https://www.npmjs.com/package/hyperhue) – Dark/Rainbow - A theme that reacts to the colors of your Philips Hue lights.
 * [hyperterm-hybrid](https://www.npmjs.com/package/hyperterm-hybrid) – Dark - Beautiful theme, based on [vim-hybrid](https://github.com/w0ng/vim-hybrid), that combines [Tomorrow-Night](https://github.com/chriskempson/vim-tomorrow-theme), [Codecademy](https://www.codecademy.com/), [Jellybeans](https://github.com/nanotech/jellybeans.vim), and [Solarized](https://github.com/altercation/vim-colors-solarized) themes together.
+* [hyperterm-title](https://www.npmjs.com/package/hyperterm-title) – Set the title of your tabs to what your shell suggests.
 * Know of another really awesome theme? [Get it on awesome-hyperterm!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Resources


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`hyperterm-title` set the title of your tabs to what your shell suggests. By default, hyperterm show on tabs the name of running process on macOS and "Shell" on Linux.
This plugin set the title of tabs in the same way that iTerm does.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the **CONTRIBUTING.md** document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (hyperterm-plugin-example)
- [x] The link for my package or theme uses the npmjs.com link (https://npmjs.com/package/hyperterm-plugin-example)
- [x] There is a visual representation of what my plugin does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the colors within HyperTerm)
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme of why it's awesome and deserves to be on the list.
