### PR TITLE
Add hyperterm-install-devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-sync-settings](https://www.npmjs.com/package/hyperterm-sync-settings) - Easy way to backup and restore HyperTerm settings to Github.
 * [hyperterm-mactabs](https://www.npmjs.com/package/hyperterm-mactabs) - Better tab styles, with macOS-inspired design and close buttons on the left, compatible with most themes.
 * [hyperterm-final-say](https://www.npmjs.com/package/hyperterm-final-say) - Allows user-set overrides of any plugin or theme settings applied on top of the defaults `./.hyperterm.js`.
+* [hyperterm-install-devtools](https://www.npmjs.com/package/hyperterm-install-devtools) - Use Chrome DevTools extension on HyperTerm.
 * Know of another Hyperterm package? [Help add it!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Themes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Install DevTools extension via Chrome Web Store, it's based on [electron-devtools-installer](https://www.npmjs.com/package/electron-devtools-installer)

![Screenshot](https://cloud.githubusercontent.com/assets/3001525/16935410/cbc9aa9e-4d91-11e6-9d59-61317b6644d1.png)

> Use [React Developer Tools](https://github.com/facebook/react-devtools) on web page (Open DevTools by [hyperterm-open-devtools](https://www.npmjs.com/package/hyperterm-open-devtools))

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the **CONTRIBUTING.md** document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (hyperterm-install-devtools)
- [x] The link for my package or theme uses the npmjs.com link (https://npmjs.com/package/hyperterm-install-devtools)
- [x] There is a visual representation of what my plugin does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the colors within HyperTerm)
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme of why it's awesome and deserves to be on the list.
