### PR TITLE
Add hyperterm-bold-tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-monokai](https://www.npmjs.com/package/hyperterm-monokai) - Dark - A port of the popular monokai theme. The colors are warm, relaxing and pleasing to the eyes.
 * [hyperterm-electron-highlighter](https://www.npmjs.com/package/hyperterm-electron-highlighter) - Dark - Port of Atom One Dark syntax colors with more vibrant colors.
 * [hyperterm-duotone-darkspace](https://www.npmjs.com/package/hyperterm-duotone-darkspace) - Dark/Orange - A beautiful dark theme inspired by [Duotone Themes](http://simurai.com/projects/2016/01/01/duotone-themes) by [Simurai](http://simurai.com/). More color variations can be found [here](https://www.npmjs.com/search?q=hyperterm-duotone-*).
-* [hyperterm-bold-tab](https://npmjs.com/package/hyperterm-bold-tab) - Bold's your active tab text. Makes keeping track of your current tab painless.
+* [hyperterm-bold-tab](https://www.npmjs.com/package/hyperterm-bold-tab) - Bold's your active tab text. Makes keeping track of your current tab painless.
 * Know of another really awesome theme? [Get it on awesome-hyperterm!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Resources

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-monokai](https://www.npmjs.com/package/hyperterm-monokai) - Dark - A port of the popular monokai theme. The colors are warm, relaxing and pleasing to the eyes.
 * [hyperterm-electron-highlighter](https://www.npmjs.com/package/hyperterm-electron-highlighter) - Dark - Port of Atom One Dark syntax colors with more vibrant colors.
 * [hyperterm-duotone-darkspace](https://www.npmjs.com/package/hyperterm-duotone-darkspace) - Dark/Orange - A beautiful dark theme inspired by [Duotone Themes](http://simurai.com/projects/2016/01/01/duotone-themes) by [Simurai](http://simurai.com/). More color variations can be found [here](https://www.npmjs.com/search?q=hyperterm-duotone-*).
+* [hyperterm-bold-tab](https://npmjs.com/package/hyperterm-bold-tab) - Bold's your active tab text. Makes keeping track of your current tab painless.
 * Know of another really awesome theme? [Get it on awesome-hyperterm!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Resources


### PR DESCRIPTION

Keeping track of your current tab is not instantly visible in the native UI. `hyperterm-bold-tab` bold's the current tab's text so that you always know where you are!

<!--- Provide a general summary of your changes in the Title above -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the **CONTRIBUTING.md** document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (hyperterm-plugin-example)
- [x] The link for my package or theme uses the npmjs.com link (https://npmjs.com/package/hyperterm-plugin-example)
- [x] There is a visual representation of what my plugin does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the colors within HyperTerm)
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme of why it's awesome and deserves to be on the list.

Bolds the active tab to make keeping track of your current location simple.