### PR TITLE
Add `hyperterm-tab-icons` to Packages List

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-sync-settings](https://www.npmjs.com/package/hyperterm-sync-settings) - Easy way to backup and restore HyperTerm settings to Github.
 * [hyperterm-mactabs](https://www.npmjs.com/package/hyperterm-mactabs) - Better tab styles, with macOS-inspired design and close buttons on the left, compatible with most themes.
 * [hyperterm-final-say](https://www.npmjs.com/package/hyperterm-final-say) - Allows user-set overrides of any plugin or theme settings applied on top of the defaults `./.hyperterm.js`.
+* [hyperterm-tab-icons](https://www.npmjs.com/package/hyperterm-tab-icons) - Add icons to the header tabs for the current running process in HyperTerm.
 * Know of another Hyperterm package? [Help add it!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Themes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the **CONTRIBUTING.md** document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (hyperterm-plugin-example)
- [x] The link for my package or theme uses the npmjs.com link (https://npmjs.com/package/hyperterm-plugin-example)
- [x] There is a visual representation of what my plugin does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the colors within HyperTerm)
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme of why it's awesome and deserves to be on the list.

`hyperterm-tab-icons` adds the awesome ability to show an icon based on the currently running process title!