### PR TITLE
Add hyperterm-dark-macos theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-bold-tab](https://www.npmjs.com/package/hyperterm-bold-tab) - Bold's your active tab text. Makes keeping track of your current tab painless.
 * [hyperterm-base16-tomorrow-dark](https://www.npmjs.com/package/hyperterm-base16-tomorrow-dark) – Dark - Hyperterm port of Atom's `Base16 Tomorrow Dark` Theme.
 * [hyperterm-firewatch](https://www.npmjs.com/package/hyperterm-firewatch) – Dark – Inspired by the [Firewatch game](http://www.firewatchgame.com/) & [atom syntax theme](https://atom.io/themes/firewatch-syntax).
+* [hyperterm-dark-macos](https://www.npmjs.com/package/hyperterm-dark-macos) - A theme that pairs nicely with macOS dark mode.
 * Know of another really awesome theme? [Get it on awesome-hyperterm!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Resources


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the **CONTRIBUTING.md** document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (hyperterm-plugin-example)
- [x] The link for my package or theme uses the npmjs.com link (https://npmjs.com/package/hyperterm-plugin-example)
- [x] There is a visual representation of what my plugin does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the colors within HyperTerm)
- [x] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme of why it's awesome and deserves to be on the list.

https://github.com/philippbosch/hyperterm-dark-macos