### PR TITLE
Add hyperterm-materialshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-panda](https://www.npmjs.com/package/hyperterm-panda) — Panda syntax theme a superminimal, dark Syntax Theme — HyperTerm port.
 * [hyperterm-cobatl2-theme](https://www.npmjs.com/package/hyperterm-cobalt2-theme) - Dusty Blue, dark with vibrant pops of colour for the important stuff. Goes well with Cobalt2 ZSH theme.
 * [hyperterm-unlease](https://www.npmjs.com/package/hyperterm-unlease) - A fresh theme for Hyperterm that makes you feel like there's one of those pine tree car air fresheners hanging from your terminal.
-* [hyperterm-materialshell](https://www.npmjs.com/package/hyperterm-materialshell) - A material design theme for HyperTerm based on [materialshell](https://github.com/carloscuesta/materialshell).
+* [hyperterm-materialshell](https://www.npmjs.com/package/hyperterm-materialshell) - A dark material design theme with a good contrast and color pops at the important parts. Designed to be easy on the eyes, based on [materialshell](https://github.com/carloscuesta/materialshell).
 * Know of another really awesome theme? [Get it on awesome-hyperterm!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Resources

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-panda](https://www.npmjs.com/package/hyperterm-panda) — Panda syntax theme a superminimal, dark Syntax Theme — HyperTerm port.
 * [hyperterm-cobatl2-theme](https://www.npmjs.com/package/hyperterm-cobalt2-theme) - Dusty Blue, dark with vibrant pops of colour for the important stuff. Goes well with Cobalt2 ZSH theme.
 * [hyperterm-unlease](https://www.npmjs.com/package/hyperterm-unlease) - A fresh theme for Hyperterm that makes you feel like there's one of those pine tree car air fresheners hanging from your terminal.
+* [hyperterm-materialshell](https://www.npmjs.com/package/hyperterm-materialshell) - A material design theme for HyperTerm based on [materialshell](https://github.com/carloscuesta/materialshell).
 * Know of another really awesome theme? [Get it on awesome-hyperterm!](https://github.com/bnb/awesome-hyperterm/issues/new)
 
 # Resources


### PR DESCRIPTION
Added the [materialshell](https://github.com/carloscuesta/materialshell) theme for HyperTerm.

## Checklist for submitting an `awesome` plugin, theme, or resource:
- [x] The title for my package or theme uses its npm title (`hyperterm-plugin-example`)
- [x] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyperterm-plugin-example)
- [x] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to HyperTerm)
- [x] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR. 

