### PR TITLE
Add hyperterm-focus-reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Like `awesome-hyperterm`? Reach out to me and say *hi* on [Twitter](https://twit
 * [hyperterm-dibdabs](https://www.npmjs.com/package/hyperterm-dibdabs) - Unique colored dot on the left of the tab is added for quick identification of commonly used tabs based on its title.
 * [hyperterm-tabs](https://www.npmjs.com/package/hyperterm-tabs) - Rearrange tabs by drag&dropping them
 * Know of another Hyperterm package? [Help add it!](https://github.com/bnb/awesome-hyperterm/issues/new)
+* [hyperterm-focus-reporting](https://www.npmjs.com/package/hyperterm-focus-reporting) - Adds focus reporting to hyperterm - similar to iterm2.
 
 # Themes
 * [hyperterm-atom-dark](https://www.npmjs.com/package/hyperterm-atom-dark) - Dark - Really beautiful import of Atom One Dark theme from the [official Atom theme](https://github.com/atom/one-dark-syntax).


### PR DESCRIPTION
I wrote this little plugin to add focus gained & focus lost reporting when running terminal vim inside hyperterm.  This way when a terminal loses focus vim will receive the `focus lost` event & in my setup it autosaves all the buffers.  I don't think there's a really good way to show a visual representation of this, but I think I've hit every other item on the checklist!

## Checklist for submitting an `awesome` plugin, theme, or resource:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the CONTRIBUTING.md document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (`hyperterm-plugin-example`)
- [x] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyperterm-plugin-example)
- [ ] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to HyperTerm)
- [x] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR. 